### PR TITLE
`GameTimer` bugfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,42 +24,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
-name = "bumpalo"
-version = "3.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
-
-[[package]]
-name = "cc"
-version = "1.0.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crossterm"
@@ -113,38 +66,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,21 +98,6 @@ dependencies = [
  "wasi",
  "windows-sys",
 ]
-
-[[package]]
-name = "num-traits"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "parking_lot"
@@ -346,7 +252,6 @@ name = "strategem-hero"
 version = "0.8.0"
 dependencies = [
  "bincode",
- "chrono",
  "crossterm",
  "rand",
  "serde",
@@ -376,60 +281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,15 +301,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.5",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ panic = "abort"
 
 [dependencies]
 crossterm = { version = "0.27" }
-chrono = { version = "0.4" }
 rand = { version = "0.8" }
 bincode = "1.3.3"
 serde = { version = "1.0.210", features = ["derive"] }

--- a/src/game.rs
+++ b/src/game.rs
@@ -7,7 +7,7 @@ use crate::{
     storage::{Leaderboard, PlayerData, Storage},
     strategem::Strategem,
     tui,
-    utility::{self, GameTimer, InputFreeze, Multiplier},
+    utility::{self, FreezeState, GameTimer, InputFreeze, Multiplier},
 };
 
 struct GameState {
@@ -129,10 +129,10 @@ impl Game {
             *strategem = crate::strategem::random();
         } else if !strategem.is_valid() {
             *streak = 0;
-            self.freeze.apply(|| {
+            if let FreezeState::Completed = self.freeze.ping() {
                 strategem.reset();
                 game_timer.sub(self.player.penalty_debuff_dur());
-            });
+            };
         }
     }
 
@@ -162,6 +162,7 @@ impl Game {
         screenln!("Restart the game [y/n]?")?;
         if tui::confirm_action()? {
             self.state.reset();
+            self.freeze.reset();
         } else {
             self.is_running = false;
         }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,10 +1,9 @@
 use std::{
     fmt::Display,
     path::{Path, PathBuf},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
-use chrono::{DateTime, TimeDelta, Utc};
 use crossterm::style::Stylize;
 
 use crate::{
@@ -16,23 +15,23 @@ const VERSION: &str = "0.8";
 
 pub struct GameTimer {
     initial_duration: Duration,
-    game_over_time: DateTime<Utc>,
+    game_over_time: std::time::Instant,
 }
 
 impl GameTimer {
     pub fn start_from(dur: Duration) -> Self {
         Self {
             initial_duration: dur,
-            game_over_time: chrono::Utc::now() + dur,
+            game_over_time: std::time::Instant::now() + dur,
         }
     }
 
-    pub fn remaining(&self) -> TimeDelta {
-        self.game_over_time - chrono::Utc::now()
+    pub fn remaining(&self) -> Duration {
+        self.game_over_time - Instant::now()
     }
 
     pub fn is_over(&self) -> bool {
-        self.game_over_time - chrono::Utc::now() <= TimeDelta::zero()
+        self.game_over_time - Instant::now() <= Duration::ZERO
     }
 
     pub fn add(&mut self, dur: Duration) {
@@ -44,14 +43,14 @@ impl GameTimer {
     }
 
     pub fn reset(&mut self) {
-        self.game_over_time = chrono::Utc::now() + self.initial_duration;
+        self.game_over_time = Instant::now() + self.initial_duration;
     }
 }
 
 impl Display for GameTimer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let step = self.initial_duration.as_secs() / 10;
-        let remaining_steps = self.remaining().num_seconds() / step as i64 + 1;
+        let remaining_steps = self.remaining().as_secs() / step + 1;
         let time_left = self.remaining();
         let steps_str = "#".repeat(remaining_steps.min(10) as usize);
 
@@ -64,8 +63,8 @@ impl Display for GameTimer {
                 _ => steps_str.green(),
             },
             " ".repeat(10 - remaining_steps.min(10) as usize),
-            time_left.num_seconds(),
-            (time_left.num_milliseconds() - time_left.num_seconds() * 1000) / 100
+            time_left.as_secs(),
+            time_left.subsec_millis() / 100
         )
     }
 }


### PR DESCRIPTION
The `chrono::Utc` is not very reliable  clock for game loop. Sometimes, it can jump few second ahead.
Replaced it with `std::time::Instant`